### PR TITLE
Remove auth header from GitHub `curl`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,4 @@ jobs:
       - image: circleci/python
     steps:
       - checkout
-      - run: curl https://api.github.com/repos/yatriks/circleci-checks-test/commits/$CIRCLE_SHA1/status -H "Authorization token $GITHUB_TOKEN"
+      - run: curl https://api.github.com/repos/yatriks/circleci-checks-test/commits/$CIRCLE_SHA1/status


### PR DESCRIPTION
This pull request is before enabling the `circleci-checks` GitHub App.
This commit's CircleCI build *does* show statuses in GitHub API status check.