### PR TITLE
Add message about checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,5 @@ jobs:
       - image: circleci/python
     steps:
       - checkout
+      - run: echo "Now, checks are enabled"
       - run: curl https://api.github.com/repos/yatriks/circleci-checks-test/commits/$CIRCLE_SHA1/status


### PR DESCRIPTION
Now, `circleci-checks` _has_ been enabled.
This commit's CircleCI build *does not* show statuses in GitHub API status check. We also expect the merge commit will not.